### PR TITLE
Change id type from XOnlyPublicKey to Sha256Hash

### DIFF
--- a/bindings/nostr-ffi/src/event/builder.rs
+++ b/bindings/nostr-ffi/src/event/builder.rs
@@ -6,8 +6,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Result;
-use bitcoin_hashes::sha256;
-use nostr::{Contact as ContactSdk, EventBuilder as EventBuilderSdk, Tag};
+use nostr::{Contact as ContactSdk, EventBuilder as EventBuilderSdk, Sha256Hash, Tag};
 use url::Url;
 
 use super::kind::Kind;
@@ -109,10 +108,10 @@ impl EventBuilder {
 
     /// Create delete event
     pub fn delete(ids: Vec<String>, reason: Option<String>) -> Result<Self> {
-        let mut new_ids: Vec<sha256::Hash> = Vec::with_capacity(ids.len());
+        let mut new_ids: Vec<Sha256Hash> = Vec::with_capacity(ids.len());
 
         for id in ids.into_iter() {
-            new_ids.push(sha256::Hash::from_str(&id)?);
+            new_ids.push(Sha256Hash::from_str(&id)?);
         }
 
         Ok(Self {

--- a/bindings/nostr-ffi/src/subscription.rs
+++ b/bindings/nostr-ffi/src/subscription.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Result;
-use nostr::SubscriptionFilter as SubscriptionFilterSdk;
+use nostr::{Sha256Hash, SubscriptionFilter as SubscriptionFilterSdk};
 use secp256k1::XOnlyPublicKey;
 
 use crate::event::kind::Kind;
@@ -65,7 +65,7 @@ impl SubscriptionFilter {
     }
 
     pub fn event(self: Arc<Self>, event_id: String) -> Result<Arc<Self>> {
-        let event_id = XOnlyPublicKey::from_str(&event_id)?;
+        let event_id = Sha256Hash::from_str(&event_id)?;
 
         let mut builder = unwrap_or_clone_arc(self);
         builder.sub_filter = builder.sub_filter.events(vec![event_id]);

--- a/crates/nostr-sdk/src/client/blocking.rs
+++ b/crates/nostr-sdk/src/client/blocking.rs
@@ -4,9 +4,8 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
-use bitcoin_hashes::sha256::Hash;
 use nostr::key::XOnlyPublicKey;
-use nostr::{Contact, Event, Keys, Metadata, SubscriptionFilter, Tag};
+use nostr::{Contact, Event, Keys, Metadata, Sha256Hash, SubscriptionFilter, Tag};
 use tokio::sync::broadcast;
 use url::Url;
 
@@ -129,7 +128,7 @@ impl Client {
 
     pub fn update_channel(
         &self,
-        channel_id: Hash,
+        channel_id: Sha256Hash,
         relay_url: Url,
         name: Option<&str>,
         about: Option<&str>,
@@ -142,7 +141,12 @@ impl Client {
         })
     }
 
-    pub fn send_channel_msg(&self, channel_id: Hash, relay_url: Url, msg: &str) -> Result<()> {
+    pub fn send_channel_msg(
+        &self,
+        channel_id: Sha256Hash,
+        relay_url: Url,
+        msg: &str,
+    ) -> Result<()> {
         RUNTIME.block_on(async {
             self.client
                 .send_channel_msg(channel_id, relay_url, msg)
@@ -150,7 +154,7 @@ impl Client {
         })
     }
 
-    pub fn hide_channel_msg(&self, message_id: Hash, reason: &str) -> Result<()> {
+    pub fn hide_channel_msg(&self, message_id: Sha256Hash, reason: &str) -> Result<()> {
         RUNTIME.block_on(async { self.client.hide_channel_msg(message_id, reason).await })
     }
 

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -5,10 +5,10 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
-use bitcoin_hashes::sha256::Hash;
 use nostr::key::XOnlyPublicKey;
 use nostr::{
-    Contact, Event, EventBuilder, Keys, Kind, KindBase, Metadata, SubscriptionFilter, Tag,
+    Contact, Event, EventBuilder, Keys, Kind, KindBase, Metadata, Sha256Hash, SubscriptionFilter,
+    Tag,
 };
 use tokio::sync::broadcast;
 use url::Url;
@@ -433,8 +433,8 @@ impl Client {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/09.md>
     pub async fn delete_event(&self, event_id: &str) -> Result<()> {
-        let event: Event =
-            EventBuilder::delete(vec![Hash::from_str(event_id)?], None).to_event(&self.keys)?;
+        let event: Event = EventBuilder::delete(vec![Sha256Hash::from_str(event_id)?], None)
+            .to_event(&self.keys)?;
         self.send_event(event).await
     }
 
@@ -518,7 +518,7 @@ impl Client {
     /// <https://github.com/nostr-protocol/nips/blob/master/28.md>
     pub async fn update_channel(
         &self,
-        channel_id: Hash,
+        channel_id: Sha256Hash,
         relay_url: Url,
         name: Option<&str>,
         about: Option<&str>,
@@ -535,7 +535,7 @@ impl Client {
     /// <https://github.com/nostr-protocol/nips/blob/master/28.md>
     pub async fn send_channel_msg(
         &self,
-        channel_id: Hash,
+        channel_id: Sha256Hash,
         relay_url: Url,
         msg: &str,
     ) -> Result<()> {
@@ -547,7 +547,7 @@ impl Client {
     /// Hide channel message
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/28.md>
-    pub async fn hide_channel_msg(&self, message_id: Hash, reason: &str) -> Result<()> {
+    pub async fn hide_channel_msg(&self, message_id: Sha256Hash, reason: &str) -> Result<()> {
         let event: Event =
             EventBuilder::hide_channel_msg(message_id, reason).to_event(&self.keys)?;
         self.send_event(event).await

--- a/crates/nostr/examples/bip340.rs
+++ b/crates/nostr/examples/bip340.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::str::FromStr;
 
 use bitcoin_hashes::hex::FromHex;
-use bitcoin_hashes::sha256;
+use nostr::Sha256Hash;
 use secp256k1::schnorr::Signature;
 use secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};
 
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let secp = Secp256k1::new();
 
         let message_str = record.get("message").ok_or("Couldn't get message");
-        let message_hash = sha256::Hash::from_hex(message_str?)?;
+        let message_hash = Sha256Hash::from_hex(message_str?)?;
         let message = Message::from_slice(&message_hash)?;
 
         let signature = record.get("signature").ok_or("Couldn't get signature");

--- a/crates/nostr/examples/delete_event.rs
+++ b/crates/nostr/examples/delete_event.rs
@@ -4,9 +4,8 @@
 use std::error::Error;
 use std::str::FromStr;
 
-use bitcoin_hashes::sha256::Hash;
 use nostr::key::{FromBech32, Keys};
-use nostr::{ClientMessage, Event, EventBuilder};
+use nostr::{ClientMessage, Event, EventBuilder, Sha256Hash};
 use tungstenite::{connect, Message as WsMessage};
 use url::Url;
 
@@ -23,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let my_keys = Keys::from_bech32(MY_BECH32_SK)?;
 
     let event_id =
-        Hash::from_str("7469af3be8c8e06e1b50ef1caceba30392ddc0b6614507398b7d7daa4c218e96")?;
+        Sha256Hash::from_str("7469af3be8c8e06e1b50ef1caceba30392ddc0b6614507398b7d7daa4c218e96")?;
 
     let event: Event = EventBuilder::delete(
         vec![event_id],

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
 use bitcoin_hashes::hex::FromHex;
-use bitcoin_hashes::sha256;
 use secp256k1::schnorr::Signature;
 use secp256k1::{Secp256k1, XOnlyPublicKey};
 use serde::{Deserialize, Deserializer};
@@ -18,10 +17,11 @@ pub mod tag;
 pub use self::builder::EventBuilder;
 pub use self::kind::{Kind, KindBase};
 pub use self::tag::{Marker, Tag, TagData, TagKind};
+use crate::Sha256Hash;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Event {
-    pub id: sha256::Hash, // hash of serialized event with id 0
+    pub id: Sha256Hash, // hash of serialized event with id 0
     pub pubkey: XOnlyPublicKey,
     pub created_at: u64, // unix timestamp seconds
     pub kind: Kind,
@@ -83,7 +83,7 @@ impl Event {
         content: &str,
         sig: &str,
     ) -> Result<Self> {
-        let id = sha256::Hash::from_hex(id)?;
+        let id = Sha256Hash::from_hex(id)?;
         let pubkey = XOnlyPublicKey::from_str(pubkey)?;
         let kind = serde_json::from_str(&kind.to_string())?;
         let sig = Signature::from_str(sig)?;
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn test_custom_kind() {
         let keys = Keys::generate_from_os_random();
-        let e: Event = EventBuilder::new(Kind::Custom(123), "my content", &vec![])
+        let e: Event = EventBuilder::new(Kind::Custom(123), "my content", &[])
             .to_event(&keys)
             .unwrap();
 

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -5,10 +5,11 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
-use bitcoin_hashes::sha256;
 use secp256k1::schnorr::Signature;
 use secp256k1::XOnlyPublicKey;
 use url::Url;
+
+use crate::Sha256Hash;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Marker {
@@ -72,7 +73,7 @@ impl FromStr for TagKind {
 
 pub enum TagData {
     Generic(TagKind, Vec<String>),
-    EventId(sha256::Hash),
+    EventId(Sha256Hash),
     PubKey(XOnlyPublicKey),
     ContactList {
         pk: XOnlyPublicKey,
@@ -83,7 +84,7 @@ pub enum TagData {
         nonce: u128,
         difficulty: u8,
     },
-    Nip10E(sha256::Hash, Url, Option<Marker>),
+    Nip10E(Sha256Hash, Url, Option<Marker>),
     Delegation {
         delegator_pk: XOnlyPublicKey,
         conditions: String,

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -6,6 +6,8 @@
 #[macro_use]
 extern crate serde;
 
+pub use secp256k1::hashes::sha256::Hash as Sha256Hash;
+
 pub mod contact;
 pub mod event;
 pub mod key;

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -4,10 +4,9 @@
 
 use std::fmt;
 
-use bitcoin_hashes::sha256::Hash;
 use serde_json::{json, Value};
 
-use crate::Event;
+use crate::{Event, Sha256Hash};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum MessageHandleError {
@@ -40,7 +39,7 @@ pub enum RelayMessage {
         subscription_id: String,
     },
     Ok {
-        event_id: Hash,
+        event_id: Sha256Hash,
         status: bool,
         message: String,
     },
@@ -64,7 +63,7 @@ impl RelayMessage {
         Self::EndOfStoredEvents { subscription_id }
     }
 
-    pub fn new_ok(event_id: Hash, status: bool, message: String) -> Self {
+    pub fn new_ok(event_id: Sha256Hash, status: bool, message: String) -> Self {
         Self::Ok {
             event_id,
             status,
@@ -145,7 +144,7 @@ impl RelayMessage {
                 return Err(MessageHandleError::InvalidMessageFormat);
             }
 
-            let event_id: Hash = serde_json::from_value(v[1].clone())
+            let event_id: Sha256Hash = serde_json::from_value(v[1].clone())
                 .map_err(|_| MessageHandleError::JsonDeserializationFailed)?;
 
             let status: bool = serde_json::from_value(v[2].clone())
@@ -270,7 +269,9 @@ mod tests {
     fn test_handle_valid_ok() -> TestResult {
         let valid_ok_msg = r#"["OK", "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30", true, "pow: difficulty 25>=24"]"#;
         let handled_valid_ok_msg = RelayMessage::new_ok(
-            Hash::from_str("b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30")?,
+            Sha256Hash::from_str(
+                "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30",
+            )?,
             true,
             "pow: difficulty 25>=24".into(),
         );

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -4,7 +4,7 @@
 
 use secp256k1::XOnlyPublicKey;
 
-use crate::Kind;
+use crate::{Kind, Sha256Hash};
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SubscriptionFilter {
@@ -16,7 +16,7 @@ pub struct SubscriptionFilter {
     kinds: Option<Vec<Kind>>,
     #[serde(rename = "#e")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    events: Option<Vec<XOnlyPublicKey>>,
+    events: Option<Vec<Sha256Hash>>,
     #[serde(rename = "#p")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pubkeys: Option<Vec<XOnlyPublicKey>>,
@@ -97,7 +97,7 @@ impl SubscriptionFilter {
     }
 
     /// Set event
-    pub fn event(self, id: XOnlyPublicKey) -> Self {
+    pub fn event(self, id: Sha256Hash) -> Self {
         Self {
             events: Some(vec![id]),
             ..self
@@ -105,7 +105,7 @@ impl SubscriptionFilter {
     }
 
     /// Set events
-    pub fn events(self, ids: Vec<XOnlyPublicKey>) -> Self {
+    pub fn events(self, ids: Vec<Sha256Hash>) -> Self {
         Self {
             events: Some(ids),
             ..self

--- a/crates/nostr/src/util/nips/nip13.rs
+++ b/crates/nostr/src/util/nips/nip13.rs
@@ -2,10 +2,10 @@
 // Copyright (c) 2022 Yuki Kishimoto
 // Distributed under the MIT software license
 
-use bitcoin_hashes::sha256;
+use crate::Sha256Hash;
 
 /// Gets the number of leading zero bits of a hash. Result is between 0 and 255.
-pub fn get_leading_zero_bits(h: sha256::Hash) -> u8 {
+pub fn get_leading_zero_bits(h: Sha256Hash) -> u8 {
     let mut res = 0_u8;
     for b in h.as_ref() {
         if *b == 0 {
@@ -49,259 +49,327 @@ pub fn get_prefixes_for_difficulty(leading_zero_bits: u8) -> Vec<String> {
 
 #[cfg(test)]
 pub mod tests {
-    use bitcoin_hashes::hex::FromHex;
-    use bitcoin_hashes::sha256::Hash;
-
     use super::*;
+    use bitcoin_hashes::hex::FromHex;
 
     #[test]
     fn check_get_leading_zeroes() {
         assert_eq!(
             4,
             get_leading_zero_bits(
-                Hash::from_hex("0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             3,
             get_leading_zero_bits(
-                Hash::from_hex("1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             1,
             get_leading_zero_bits(
-                Hash::from_hex("4fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "4fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             1,
             get_leading_zero_bits(
-                Hash::from_hex("5fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "5fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             1,
             get_leading_zero_bits(
-                Hash::from_hex("6fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "6fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             1,
             get_leading_zero_bits(
-                Hash::from_hex("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
 
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("afffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "afffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("cfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "cfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("dfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "dfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             0,
             get_leading_zero_bits(
-                Hash::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
 
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("20ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "20ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("21ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "21ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("22ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "22ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("23ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "23ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("24ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "24ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("25ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "25ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("26ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "26ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("27ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "27ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("28ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "28ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("29ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "29ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             2,
             get_leading_zero_bits(
-                Hash::from_hex("2fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "2fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
         );
 
         assert_eq!(
             248,
             get_leading_zero_bits(
-                Hash::from_hex("00000000000000000000000000000000000000000000000000000000000000ff")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "00000000000000000000000000000000000000000000000000000000000000ff"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             252,
             get_leading_zero_bits(
-                Hash::from_hex("000000000000000000000000000000000000000000000000000000000000000f")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "000000000000000000000000000000000000000000000000000000000000000f"
+                )
+                .unwrap()
             )
         );
         assert_eq!(
             255,
             get_leading_zero_bits(
-                Hash::from_hex("0000000000000000000000000000000000000000000000000000000000000001")
-                    .unwrap()
+                Sha256Hash::from_hex(
+                    "0000000000000000000000000000000000000000000000000000000000000001"
+                )
+                .unwrap()
             )
         );
     }

--- a/crates/nostr/src/util/nips/nip26.rs
+++ b/crates/nostr/src/util/nips/nip26.rs
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license
 
 use anyhow::Result;
-use bitcoin_hashes::{sha256, Hash};
+use bitcoin_hashes::Hash;
 use secp256k1::schnorr::Signature;
 use secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};
 
 use crate::key::Keys;
+use crate::Sha256Hash;
 
 pub fn sign_delegation(
     keys: &Keys,
@@ -16,7 +17,7 @@ pub fn sign_delegation(
     let secp = Secp256k1::new();
     let keypair: &KeyPair = &keys.key_pair()?;
     let unhashed_token: String = format!("nostr:delegation:{}:{}", delegatee_pk, conditions);
-    let hashed_token = sha256::Hash::hash(unhashed_token.as_bytes());
+    let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
     Ok(secp.sign_schnorr(&message, keypair))
 }


### PR DESCRIPTION
This changes the type of event ID in some places from `XOnlyPublicKey` to `Sha256Hash`, like for example in `bindings/nostr-ffi/src/subscription.rs` :

https://github.com/ok300/nostr-rs-sdk/commit/d81d45ec236deeaae2b0130ca5f4f34b0b9383f1#diff-12a81a45d00b2eb02fa872873da2ed071b0db52e412bf2cd2fa97e5b5cf0f972

To keep things consistent, I also replaced other uses of `sha256::Hash` with the alias `Sha256Hash`.