### PR TITLE
WASM support

### DIFF
--- a/crates/nostr-sdk/Cargo.toml
+++ b/crates/nostr-sdk/Cargo.toml
@@ -16,7 +16,9 @@ default = ["all-nips"]
 blocking = ["dep:once_cell"]
 all-nips = ["nostr/all-nips"]
 nip04 = ["nostr/nip04"]
+nip05 = ["nostr/nip05"]
 nip06 = ["nostr/nip06"]
+nip11 = ["nostr/nip11"]
 
 [dependencies]
 futures-util = "0.3"

--- a/crates/nostr-sdk/README.md
+++ b/crates/nostr-sdk/README.md
@@ -100,7 +100,9 @@ The following crate feature flags are available:
 | `blocking`          |   No    | Needed to use this library in not async/await context                                                                      |
 | `all-nips`          |   Yes   | Enable all NIPs                                                                                                            |
 | `nip04`             |   Yes   | Enable NIP-04: Encrypted Direct Message                                                                                    |
+| `nip05`             |   Yes   | Enable NIP-05: Mapping Nostr keys to DNS-based internet identifiers |
 | `nip06`             |   Yes   | Enable NIP-06: Basic key derivation from mnemonic seed phrase                                                              |
+| `nip11`             |   Yes   | Enable NIP-11: Relay Information Document |
 
 ## State
 

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -13,9 +13,11 @@ keywords = ["nostr", "protocol", "sdk", "rust"]
 
 [features]
 default = ["all-nips"]
-all-nips = ["nip04", "nip06"]
+all-nips = ["nip04", "nip06", "nip05", "nip11"]
 nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
+nip05 = ["dep:reqwest"]
 nip06 = ["dep:bip39"]
+nip11 = ["dep:reqwest"]
 
 [dependencies]
 aes = { version = "0.8", optional = true }
@@ -26,7 +28,7 @@ cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4"
 once_cell = "1"
 regex = "1.7"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls-webpki-roots", "socks"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking", "json", "rustls-tls-webpki-roots", "socks"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
@@ -42,5 +44,13 @@ name = "nip04"
 required-features = ["nip04"]
 
 [[example]]
+name = "nip05"
+required-features = ["nip05"]
+
+[[example]]
 name = "nip06"
 required-features = ["nip06"]
+
+[[example]]
+name = "nip11"
+required-features = ["nip11"]

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -80,7 +80,9 @@ The following crate feature flags are available:
 | ------------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------- |
 | `all-nips`          |   Yes   | Enable all NIPs                                                                                                            |
 | `nip04`             |   Yes   | Enable NIP-04: Encrypted Direct Message                                                                                    |
+| `nip05`             |   Yes   | Enable NIP-05: Mapping Nostr keys to DNS-based internet identifiers |
 | `nip06`             |   Yes   | Enable NIP-06: Basic key derivation from mnemonic seed phrase                                                              |
+| `nip11`             |   Yes   | Enable NIP-11: Relay Information Document |
 
 ## Supported NIPs
 

--- a/crates/nostr/src/util/nips/mod.rs
+++ b/crates/nostr/src/util/nips/mod.rs
@@ -3,9 +3,11 @@
 
 #[cfg(feature = "nip04")]
 pub mod nip04;
+#[cfg(feature = "nip05")]
 pub mod nip05;
 #[cfg(feature = "nip06")]
 pub mod nip06;
+#[cfg(feature = "nip11")]
 pub mod nip11;
 pub mod nip13;
 pub mod nip26;


### PR DESCRIPTION
### Description

The reqwest dependency breaks the wasm32-unknown-unknown build target. I've moved the two nips that use reqwest behind feature flags

