### PR TITLE
Increase event kind range

### DIFF
--- a/bindings/nostr-ffi/src/event/kind.rs
+++ b/bindings/nostr-ffi/src/event/kind.rs
@@ -5,7 +5,7 @@ use nostr::event::kind::{Kind as KindSdk, KindBase};
 
 pub enum Kind {
     Base { kind: KindBase },
-    Custom { kind: u16 },
+    Custom { kind: u64 },
 }
 
 impl From<KindSdk> for Kind {

--- a/bindings/nostr-ffi/src/nostr.udl
+++ b/bindings/nostr-ffi/src/nostr.udl
@@ -27,7 +27,7 @@ enum KindBase {
 [Enum]
 interface Kind {
     Base(KindBase kind);
-    Custom(u16 kind);
+    Custom(u64 kind);
 };
 
 interface Keys {

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -25,5 +25,5 @@ pub enum KindBase {
 #[serde(untagged)]
 pub enum Kind {
     Base(KindBase),
-    Custom(u16),
+    Custom(u64),
 }


### PR DESCRIPTION
### Description

Increase event kind range from u16 to u64.

### Notes to the reviewers

Some recent events have an ID that's way outside the current Kind range, like this one:

```json
{
    "id":"0f71974d06ceda0024317b9a370de6d904cd5038e81c27087335308486d64e07",
    "pubkey":"543210b5f6c3071c3135d850449f8bf91efffb5ed1153e5fcbb2d95b79262b57",
    "created_at":1671154736,
    "kind":641204,
    "tags":[["sequence","825"],["height","767602"]],
    "content":"{\"document_uid\":\"9827d8ede1572958ef01b67aee20618be038af2976b9aee0b175c3624e93b997\",\"patch_uid\":\"2d0a805f187eff484a172a68fa98ff6c0337abfe8c4e8020905aa3665016cc41\",\"operation\":2,\"reason\":\"\",\"sequence\":13}",
    "sig":"5300d608310b655c7f8d9ebfc8e1aca0e183dbca68e682df4ca72eec440d1ebb34ae807840e14f83bf9c5ea6a4c61cd99b3d9bae553746d4332f006ef98f77f9"
}
```

Even though [NIP-16](https://github.com/nostr-protocol/nips/blob/master/16.md) describes kinds up to 30k, this one had a kind of 640k and was accepted by the relay. So the range limit is relatively arbitrary and this SDK should probably support a wide range of values.

### Changelog notice

Increase supported kind range from u16 (max 65535) to u64 (up to about 1.8x10^19)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing