### PR TITLE
Increase channel size for receiving events and sending notifications

### DIFF
--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -77,7 +77,7 @@ pub struct Relay {
 impl Relay {
     /// Create new `Relay`
     pub fn new(url: Url, pool_sender: Sender<RelayPoolEvent>, proxy: Option<SocketAddr>) -> Self {
-        let (relay_sender, relay_receiver) = mpsc::channel::<RelayEvent>(64);
+        let (relay_sender, relay_receiver) = mpsc::channel::<RelayEvent>(1024);
 
         Self {
             url,

--- a/crates/nostr-sdk/src/relay/pool.rs
+++ b/crates/nostr-sdk/src/relay/pool.rs
@@ -123,8 +123,8 @@ impl Default for RelayPool {
 impl RelayPool {
     /// Create new `RelayPool`
     pub fn new() -> Self {
-        let (notification_sender, _) = broadcast::channel(64);
-        let (pool_task_sender, pool_task_receiver) = mpsc::channel(64);
+        let (notification_sender, _) = broadcast::channel(1024);
+        let (pool_task_sender, pool_task_receiver) = mpsc::channel(1024);
 
         let mut relay_pool_task =
             RelayPoolTask::new(pool_task_receiver, notification_sender.clone());


### PR DESCRIPTION
### Description

Increase the tokio channel sizes from 64 to 1024.

### Notes to the reviewers

These channels are used to buffer the received messages and notifications. If they are not consumed (via `client.notifications()`) fast enough, the receiving loop will fail with [RecvError::Lagged](https://docs.rs/tokio/latest/tokio/sync/broadcast/error/enum.RecvError.html#variant.Lagged), indicating the receiver "lagged" behind and some events got lost.

In my case, the consumer was parsing the message and adding it to a DB transaction. For more complex messages, this took a few milliseconds. That was slow enough to lead to lost messages.

The receive loop:

```rust
    let mut notifications = client.notifications();
    loop {
        match notifications.recv().await {
            Ok(notification) => {
                // process it
            }
            Err(e) => {
                match e {
                    RecvError::Closed => {
                        error!("Client reported stream as closed");
                        break;
                    }
                    RecvError::Lagged(e) => {
                        error!("Received error: {}", e.to_string());
                    }
                }
            }
        }
    }
```
resulting in

```
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 1
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 1
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 1
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 102
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 137
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 32
[2022-12-28T20:08:10Z ERROR nostr_sdk::net] Received error: channel lagged by 76
```

Increasing the channel sizes to 1024 eliminated these errors for me.

### Changelog notice

Increase buffer for receiving messages

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing