### PR TITLE
time support for wasm target

### DIFF
--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -36,6 +36,9 @@ serde_repr = "0.1"
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = { version = "0.1", features = [ "stdweb", "inaccurate" ] }
+
 [dev-dependencies]
 csv = "1.1.5"
 env_logger = "0.8.2"

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1,11 +1,10 @@
 // Copyright (c) 2022 Yuki Kishimoto
 // Distributed under the MIT software license
 
-
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2022 Yuki Kishimoto
 // Distributed under the MIT software license
 
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};

--- a/crates/nostr/src/util/time.rs
+++ b/crates/nostr/src/util/time.rs
@@ -1,7 +1,13 @@
 // Copyright (c) 2022 Yuki Kishimoto
 // Distributed under the MIT software license
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(target_arch = "wasm32")]
+use instant::SystemTime;
+#[cfg(target_arch = "wasm32")]
+const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
 /// Timestamp in seconds
 pub fn timestamp() -> u64 {


### PR DESCRIPTION

### Description

When building for the wasm32-unknown-unknown target, calling `Instant::now()` panics because the web browser environment has no access to the system clock. [This crate](https://crates.io/crates/instant) is a drop-in replacement for `std::time::Instant` that works for WASM. 

### Notes to the reviewers

I've added the instant crate as a dependency only when compiling for wasm. An alternative is to add it as a general dependency and remove the `#[cfg(not(target_arch = "wasm32"))]` directives. When building for any other target than wasm `instant::Instant` is just a type alias to `std::time::Instant`

